### PR TITLE
fix(preferences): avoid 406 by using .maybeSingle() when reading user…

### DIFF
--- a/src/lib/user-preferences.ts
+++ b/src/lib/user-preferences.ts
@@ -20,7 +20,7 @@ export async function getUserSafety(
       .from('user_safety')
       .select('*')
       .eq('user_id', userId)
-      .single();
+      .maybeSingle();
 
     if (error) {
       if (error.code === 'PGRST116') {
@@ -90,7 +90,7 @@ export async function getCookingPreferences(
       .from('cooking_preferences')
       .select('*')
       .eq('user_id', userId)
-      .single();
+      .maybeSingle();
 
     if (error) {
       if (error.code === 'PGRST116') {


### PR DESCRIPTION
…_safety and cooking_preferences\n\n- Replaces .single() with .maybeSingle() for empty-table safe reads\n- Keeps null handling unchanged so UX is the same\n- Production should stop returning 406 for first-time users