### PR TITLE
security: remove unsafe-inline from CSP policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.openai.com https://*.supabase.co wss://*.supabase.co; object-src 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.openai.com https://*.supabase.co wss://*.supabase.co; object-src 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     }


### PR DESCRIPTION
Removes 'unsafe-inline' from script-src and style-src for enhanced XSS protection.

Security Benefits:
- Eliminates unnecessary XSS attack vector
- Follows modern CSP best practices
- Maintains full application functionality
- No performance impact

Technical Verification:
- Tested locally - app works perfectly without unsafe-inline
- Vite build generates external JS/CSS files (no inline code needed)
- All React components work with strict CSP
- Forms, navigation, and service worker fully functional

Implements: Reviewer's valid security recommendation
Resolves: Overly permissive CSP policy