### PR TITLE
fix: Remove Edit/Delete actions from community recipes in explore page

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -215,6 +215,16 @@ export function Header() {
               Explore
             </Button>
             <Button
+              variant={location.pathname === '/groceries' ? 'default' : 'ghost'}
+              onClick={() => {
+                navigate('/groceries');
+                closeMobileMenu();
+              }}
+              className={`w-full justify-start ${location.pathname === '/groceries' ? 'bg-success text-success-content hover:bg-success/80' : ''}`}
+            >
+              My Groceries
+            </Button>
+            <Button
               variant={
                 location.pathname === '/evaluation-report' ? 'default' : 'ghost'
               }

--- a/src/components/recipes/recipe-card.tsx
+++ b/src/components/recipes/recipe-card.tsx
@@ -43,6 +43,7 @@ interface RecipeCardProps {
   onShareToggle?:
     | ((recipeId: string, isPublic: boolean) => void)
     | (() => void);
+  showEditDelete?: boolean; // New prop to control Edit/Delete visibility
 }
 
 export function RecipeCard({
@@ -51,6 +52,7 @@ export function RecipeCard({
   onView,
   showShareButton,
   onShareToggle,
+  showEditDelete = true, // Default to true for backward compatibility
 }: RecipeCardProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
@@ -300,16 +302,18 @@ export function RecipeCard({
                 </button>
               </li>
 
-              {/* Edit Button */}
-              <li>
-                <button
-                  onClick={() => onEdit?.(recipe)}
-                  className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <Edit className="h-5 w-5 text-green-600" />
-                  <span>Edit Recipe</span>
-                </button>
-              </li>
+              {/* Edit Button - Only show if showEditDelete is true */}
+              {showEditDelete && (
+                <li>
+                  <button
+                    onClick={() => onEdit?.(recipe)}
+                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-colors"
+                  >
+                    <Edit className="h-5 w-5 text-green-600" />
+                    <span>Edit Recipe</span>
+                  </button>
+                </li>
+              )}
 
               {/* Share Button */}
               {canShare && (
@@ -337,16 +341,18 @@ export function RecipeCard({
                 </li>
               )}
 
-              {/* Delete Button */}
-              <li>
-                <button
-                  onClick={() => setShowDeleteDialog(true)}
-                  className="flex items-center gap-3 p-3 rounded-lg hover:bg-red-50 transition-colors text-red-600"
-                >
-                  <Trash2 className="h-5 w-5" />
-                  <span>Delete Recipe</span>
-                </button>
-              </li>
+              {/* Delete Button - Only show if showEditDelete is true */}
+              {showEditDelete && (
+                <li>
+                  <button
+                    onClick={() => setShowDeleteDialog(true)}
+                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-red-50 transition-colors text-red-600"
+                  >
+                    <Trash2 className="h-5 w-5" />
+                    <span>Delete Recipe</span>
+                  </button>
+                </li>
+              )}
             </ul>
 
             {/* Close Button */}

--- a/src/pages/explore-page.tsx
+++ b/src/pages/explore-page.tsx
@@ -62,16 +62,7 @@ export default function ExplorePage() {
     window.open(`/recipe/${recipe.id}`, '_blank');
   };
 
-  const handleEditRecipe = (recipe: Recipe) => {
-    // For public recipes, we can't edit them directly
-    // Instead, save them to user's collection first
-    toast({
-      title: 'Info',
-      description:
-        'Public recipes must be saved to your collection before editing',
-    });
-    handleSaveRecipe(recipe.id);
-  };
+  // Remove handleEditRecipe - community recipes should not be editable
 
   const handleShareToggle = () => {
     // For public recipes, sharing is already enabled
@@ -250,9 +241,9 @@ export default function ExplorePage() {
               <RecipeCard
                 recipe={recipe}
                 onView={handleViewRecipe}
-                onEdit={handleEditRecipe}
                 showShareButton={false}
                 onShareToggle={handleShareToggle}
+                showEditDelete={false} // Hide Edit/Delete for community recipes
               />
 
               {/* Author info and save button */}


### PR DESCRIPTION
- Add showEditDelete prop to RecipeCard component to control Edit/Delete visibility
- Hide Edit and Delete buttons for community recipes in explore page
- Keep View and Save functionality intact for community recipes
- Maintain backward compatibility with default showEditDelete=true
- Fix mobile navigation by adding missing My Groceries link

This ensures community recipes are read-only in the explore page while allowing users to save them as their own editable copies.