### PR TITLE
Chore/explore view recipe fix

### DIFF
--- a/src/hooks/use-recipes.ts
+++ b/src/hooks/use-recipes.ts
@@ -25,6 +25,17 @@ export const useRecipe = (id: string) => {
   });
 };
 
+export const usePublicRecipe = (id: string, options?: { enabled?: boolean }) => {
+  return useQuery({
+    queryKey: ['public-recipe', id],
+    queryFn: () => recipeApi.getPublicRecipe(id),
+    enabled: !!id && (options?.enabled ?? true),
+    staleTime: 10 * 60 * 1000, // 10 minutes - individual recipes change less frequently
+    gcTime: 30 * 60 * 1000, // 30 minutes - keep individual recipes cached longer
+    refetchOnWindowFocus: false,
+  });
+};
+
 // New hook for recipe summaries (used in lists)
 export const useRecipeSummary = (id: string) => {
   return useQuery({

--- a/src/hooks/use-recipes.ts
+++ b/src/hooks/use-recipes.ts
@@ -25,7 +25,10 @@ export const useRecipe = (id: string) => {
   });
 };
 
-export const usePublicRecipe = (id: string, options?: { enabled?: boolean }) => {
+export const usePublicRecipe = (
+  id: string,
+  options?: { enabled?: boolean }
+) => {
   return useQuery({
     queryKey: ['public-recipe', id],
     queryFn: () => recipeApi.getPublicRecipe(id),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -237,6 +237,37 @@ export const recipeApi = {
     return data;
   },
 
+  // Get a single public recipe by ID (any public recipe)
+  async getPublicRecipe(id: string): Promise<PublicRecipe | null> {
+    const { data: recipe, error: recipeError } = await supabase
+      .from('recipes')
+      .select('*')
+      .eq('id', id)
+      .eq('is_public', true)
+      .single();
+
+    if (recipeError) handleError(recipeError, 'Get public recipe');
+    if (!recipe) return null;
+
+    // Get author name from profiles
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('full_name')
+      .eq('id', recipe.user_id)
+      .single();
+
+    if (profileError) {
+      console.warn(
+        'Could not fetch author name for public recipe:',
+        profileError
+      );
+    }
+
+    return {
+      ...recipe,
+      author_name: profile?.full_name || 'Anonymous',
+    } as PublicRecipe;
+  },
   // Get recipe summary (optimized for list views)
   async getRecipeSummary(id: string): Promise<Partial<Recipe> | null> {
     const { data, error } = await supabase

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -569,3 +569,4 @@ export const recipeApi = {
   // Parse recipe from text (delegates to recipe-parser)
   parseRecipeFromText,
 };
+// Formatting fix

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -261,6 +261,7 @@ export const recipeApi = {
         'Could not fetch author name for public recipe:',
         profileError
       );
+      trackAPIError('Fetch author profile for public recipe', profileError);
     }
 
     return {


### PR DESCRIPTION
This pull request adds support for viewing public recipes by introducing a new API method and hook, and updates the recipe view page to gracefully fall back to public recipes if a user-specific recipe cannot be retrieved. This improves the user experience for unauthenticated users or when accessing public recipes directly.

**Public recipe support:**

* Added a new API method `getPublicRecipe` to `recipeApi` in `src/lib/api.ts`, which fetches a public recipe by ID and includes the author's name from the `profiles` table.
* Introduced a new hook `usePublicRecipe` in `src/hooks/use-recipes.ts` for querying public recipes, with caching and refetching options tailored for less frequently changing data.

**Recipe view page logic:**

* Updated `src/pages/recipe-view-page.tsx` to use both `useRecipe` and `usePublicRecipe`, falling back to the public recipe if the user recipe is not found, and handling loading and error states accordingly.
* Modified imports in `src/pages/recipe-view-page.tsx` to include the new `usePublicRecipe` hook.

**Miscellaneous:**

* Minor formatting fix in `src/lib/api.ts`.