### PR TITLE
Fix/recipe view redirect issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,14 +122,12 @@ function AppContent() {
       <Route
         path="/recipe/:id"
         element={
-          <ProtectedRoute requiresAuth={false}>
-            <div className="bg-base-100 min-h-screen">
-              <Header />
-              <main>
-                <RecipeViewPage />
-              </main>
-            </div>
-          </ProtectedRoute>
+          <div className="bg-base-100 min-h-screen">
+            <Header />
+            <main>
+              <RecipeViewPage />
+            </main>
+          </div>
         }
       />
       <Route

--- a/src/pages/recipe-view-page.tsx
+++ b/src/pages/recipe-view-page.tsx
@@ -6,10 +6,12 @@ import { createDaisyUISkeletonClasses } from '@/lib/skeleton-migration';
 import { ChefHat } from 'lucide-react';
 import { RecipeDiagnostic } from '@/components/debug/RecipeDiagnostic';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthProvider';
 
 export function RecipeViewPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
 
   // Debug logging
   console.log('🔍 [RecipeViewPage] Component initialized:', {
@@ -17,6 +19,8 @@ export function RecipeViewPage() {
     timestamp: new Date().toISOString(),
     url: window.location.href,
     isProduction: import.meta.env.PROD,
+    hasUser: !!user,
+    authLoading,
   });
 
   // Optimize: Try public recipe first for better performance on public recipe pages
@@ -26,8 +30,12 @@ export function RecipeViewPage() {
     error: publicError,
   } = usePublicRecipe(id!);
 
-  // Only fetch user recipe if public recipe failed and we have auth
-  const shouldFetchUser = !publicLoading && !publicRecipe && !!publicError;
+  // Only fetch user recipe if:
+  // 1. Public recipe failed AND
+  // 2. We have a valid authenticated user AND
+  // 3. Auth is not still loading
+  const shouldFetchUser =
+    !publicLoading && !publicRecipe && !!publicError && !!user && !authLoading;
   const {
     data: userRecipe,
     isLoading: userLoading,
@@ -57,6 +65,8 @@ export function RecipeViewPage() {
     publicError: publicError?.message,
     finalError: error?.message,
     shouldFetchUser,
+    hasUser: !!user,
+    authLoading,
   });
 
   if (isLoading) {


### PR DESCRIPTION
This pull request updates the recipe view page logic to improve handling of public and user-specific recipes. The main change is that the app now only attempts to fetch a user-specific recipe if the user is authenticated and authentication is not still loading, preventing unnecessary fetches and improving reliability for unauthenticated users. Additionally, the protected route wrapper has been removed from the recipe view route, making the page publicly accessible.

**Authentication and recipe fetching logic:**

* Updated the condition for fetching user-specific recipes in `RecipeViewPage` to require a valid authenticated user and that authentication is not loading, in addition to the public recipe fetch failing.
* Added usage of `useAuth` context to `RecipeViewPage` to access authentication state and user information.
* Enhanced debug logging in `RecipeViewPage` to include authentication state details.

**Routing changes:**

* Removed the `ProtectedRoute` wrapper from the `/recipe/:id` route in `App.tsx`, allowing the recipe view page to be accessed without authentication.