### PR TITLE
chore(docs): format phase-0 docs with Prettier

### DIFF
--- a/docs/phase-0/BRANCH_AUDIT.md
+++ b/docs/phase-0/BRANCH_AUDIT.md
@@ -1,0 +1,20 @@
+# Phase 0 – Recipe Description: Branch Audit
+
+## Summary
+
+- Scope violation: edits to src/lib/supabase.ts despite guardrails.
+- Emergency reverts indicate instability in a feature branch.
+- Build passes with dynamic/static import warnings; lint shows 24 warnings.
+- Current code already threads description through schema, parsers, and UI; DB persistence appears partial.
+
+## Evidence
+
+- Commits touching supabase.ts: reverts and env validation churn.
+- Diff vs origin/main shows only two files modified on this branch (doc + supabase.ts).
+- Lint warnings are unrelated but add noise.
+
+## Lessons
+
+- Keep infra/env out of feature branches.
+- Ship in additive, scoped PRs; avoid broad refactors.
+- Prefer docs-first plan with explicit guardrails.

--- a/docs/phase-0/PR1_TYPES_UI.md
+++ b/docs/phase-0/PR1_TYPES_UI.md
@@ -1,0 +1,22 @@
+# PR 1 — Types/Schema + Minimal UI
+
+## Scope
+
+- Add description to zod schema with default ''.
+- TS types: description: string | null for persisted; UI normalized ''.
+- Form textarea + view display; parser normalization.
+
+## Files
+
+- src/lib/schemas.ts, src/lib/types.ts
+- src/components/recipes/recipe-form.tsx, src/components/recipes/recipe-view.tsx
+- src/lib/recipe-parser\*.ts
+
+## Tests
+
+- Unit: schema accepts/omits description; types compile.
+- Component: form renders textarea; view displays when provided.
+
+## Guardrails
+
+- No DB, no supabase.ts/env changes.

--- a/docs/phase-0/PR2_PROMPTS.md
+++ b/docs/phase-0/PR2_PROMPTS.md
@@ -1,0 +1,14 @@
+# PR 2 — Persona/Prompt Updates
+
+## Scope
+
+- Update SAVE_RECIPE_PROMPT + personas to include description and guidance.
+- No DB changes.
+
+## Files
+
+- src/lib/openai.ts, api/ai/chat.ts (templates only).
+
+## Tests
+
+- Unit snapshot of templates.

--- a/docs/phase-0/PR3_DB.md
+++ b/docs/phase-0/PR3_DB.md
@@ -1,0 +1,19 @@
+# PR 3 — Persistence: DB + Read/Write
+
+## Scope
+
+- Migrations: add nullable description columns to recipes and recipe_content_versions.
+- Read/write in API and client; version payloads include description.
+
+## Files
+
+- supabase/migrations/_\_add_recipe_descriptions_.sql
+- src/lib/api/\*\*, src/components/recipes/versioned-recipe-card.tsx
+
+## Safety
+
+- Additive, reversible; no data loss.
+
+## Tests
+
+- Integration save/load description present/absent.

--- a/docs/phase-0/PR4_VERSIONING.md
+++ b/docs/phase-0/PR4_VERSIONING.md
@@ -1,0 +1,13 @@
+# PR 4 — Versioning Integration
+
+## Scope
+
+- Include description in version creation and comparison; treat null/'' equal.
+
+## Files
+
+- src/lib/api/features/versioning-api.ts, versioned UI.
+
+## Tests
+
+- Integration: create version, verify description.

--- a/docs/phase-0/PR5_E2E.md
+++ b/docs/phase-0/PR5_E2E.md
@@ -1,0 +1,9 @@
+# PR 5 — E2E Coverage
+
+## Scope
+
+- E2E happy paths: edit, save, view description (no external AI).
+
+## Files
+
+- tests/e2e/_recipe-description_.spec.ts

--- a/docs/phase-0/PR6_IMAGE_GEN.md
+++ b/docs/phase-0/PR6_IMAGE_GEN.md
@@ -1,0 +1,13 @@
+# PR 6 — Image Generation Prefers Description
+
+## Scope
+
+- Prompt builders prefer description; UI nudge.
+
+## Files
+
+- src/lib/ai-image-generation/\* (prompt builders), recipe-form enablement.
+
+## Tests
+
+- Unit: builder prefers description when present.

--- a/docs/phase-0/PR_PLAN.md
+++ b/docs/phase-0/PR_PLAN.md
@@ -1,0 +1,41 @@
+# Phase 0 – Recipe Description: PR Plan (Restart)
+
+Goal: deliver description support in safe, reviewable increments (≤ 1,500 LOC each), no infra churn.
+
+## PR 1 — Types, schema, and minimal UI (no persistence)
+
+- Scope: add optional description to zod form schema (default ''), align TS types (persisted string | null; UI normalized to ''). Add textarea to recipe form and read-only block to recipe view. Parser normalizes to ''.
+- Out of scope: DB writes, migrations, prompt changes.
+- Tests: unit (schema), component (form/view).
+- Guardrails: no changes to src/lib/supabase.ts or env.
+
+## PR 2 — Persona/prompt updates (AI output schema only)
+
+- Scope: update SAVE_RECIPE_PROMPT and personas to include description and guidance. No runtime/env changes; no DB changes.
+- Tests: unit snapshot of prompt templates.
+
+## PR 3 — Persistence: DB migration + read/write
+
+- Scope: add nullable description columns to recipes and recipe_content_versions (additive). API/client read/write; UI tolerates null. Version payloads carry description.
+- Safety: additive migration; no backfill required; treat null and '' as empty.
+- Tests: integration save/load with and without description.
+
+## PR 4 — Versioning integration
+
+- Scope: include description in new version creation and diff logic; treat null/'' equivalently.
+- Tests: integration on versioned UI.
+
+## PR 5 — E2E coverage
+
+- Scope: happy-path for editing, saving, viewing description (stub AI).
+
+## PR 6 — Image generation prefers description
+
+- Scope: prompt builders prefer description; UI nudge.
+- Tests: unit on prompt builder.
+
+## Guardrails (All PRs)
+
+- No changes to src/lib/supabase.ts or env handling.
+- Keep PRs small; avoid refactors.
+- CI must pass (build, unit/component).


### PR DESCRIPTION
This pull request adds a comprehensive PR plan and supporting documentation for Phase 0 of the "Recipe Description" feature. It outlines a sequence of six incremental, tightly scoped PRs, each focused on a distinct aspect of delivering description support to recipes, with strong guardrails to prevent infrastructure churn and maintain code stability. The documentation includes rationale, lessons learned from previous branch audits, and detailed breakdowns of scope, files, and testing for each PR.

**PR Plan and Documentation Improvements**

* Added `PR_PLAN.md` detailing the overall strategy: six incremental PRs for recipe description support, each with clear scope, guardrails, and testing requirements.
* Added branch audit documentation summarizing lessons learned, evidence of scope violations, and recommendations for safer, more focused PRs.

**Feature PR Documentation**

* Documented PR 1: Types/schema and minimal UI for description, with explicit guardrails against DB and infra changes.
* Documented PR 2: Updates to AI persona prompts to include description, with template-only changes and unit snapshot tests.
* Documented PR 3: DB migration and API/client read/write for description, with additive migration and integration tests.
* Documented PR 4: Versioning integration to include description in version creation and diff logic, with integration tests.
* Documented PR 5: E2E test coverage for editing, saving, and viewing description.
* Documented PR 6: Image generation prompt builders prefer description, with supporting unit tests.