### PR TITLE
Chores/documentation cleanup

### DIFF
--- a/docs/plans/filter-bar-modernization/MIGRATION-GUIDE.md
+++ b/docs/plans/filter-bar-modernization/MIGRATION-GUIDE.md
@@ -601,7 +601,7 @@ const useContextFilters = () => {
 
 - [FilterBar Component API](./README.md#component-api)
 - [Development Guidelines](../DEV-GUIDE.md)
-- [Testing Guide](../TESTING-GUIDE.md)
+- [Testing Guide](../testing/TESTING-GUIDE.md)
 
 ### **Examples**
 

--- a/docs/plans/filter-bar-modernization/PHASE-4.md
+++ b/docs/plans/filter-bar-modernization/PHASE-4.md
@@ -562,7 +562,7 @@ npm run audit:performance       # Performance audit
 - [ ] `README.md` - Updated with new FilterBar usage
 - [ ] `MIGRATION-GUIDE.md` - Complete migration documentation
 - [ ] `DEV-GUIDE.md` - Development guidelines updated
-- [ ] `TESTING-GUIDE.md` - Testing patterns updated
+- [ ] `testing/TESTING-GUIDE.md` - Testing patterns updated
 - [ ] Component JSDoc - Comprehensive API documentation
 
 ### **Architecture Documentation**

--- a/docs/plans/filter-bar-modernization/README.md
+++ b/docs/plans/filter-bar-modernization/README.md
@@ -537,7 +537,7 @@ src/hooks/
 - [Filter Bar Architecture Audit Report](../audit/filter-bar-audit.md)
 - [Profile Modularization Success Story](../profile-modularization/) (similar project)
 - [Component Architecture Guidelines](../../DEV-GUIDE.md)
-- [Testing Strategy Guide](../../TESTING-GUIDE.md)
+- [Testing Strategy Guide](../../testing/TESTING-GUIDE.md)
 
 ### **Team Resources**
 

--- a/docs/testing/TESTING-GUIDE.md
+++ b/docs/testing/TESTING-GUIDE.md
@@ -1,0 +1,10 @@
+# Profile System Testing Guide
+
+Moved from `docs/TESTING-GUIDE.md` to consolidate testing docs.
+
+Refer to:
+
+- `docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md`
+- `docs/quality-assurance/PRE-PR-VERIFICATION.md`
+
+For full original guide content, see repository history.

--- a/docs/testing/auth/README.md
+++ b/docs/testing/auth/README.md
@@ -1,0 +1,5 @@
+# Auth Testing Docs
+
+- Password validation test suite: [Password Validation Tests](../../auth/PASSWORD_VALIDATION_TESTS.md)
+
+This section indexes authentication-related testing documentation centralized under the testing docs tree.

--- a/docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md
+++ b/docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md
@@ -43,9 +43,10 @@ The real hook returns `AuthContextType`. Mock with the full shape:
 ```ts
 vi.mock('@/contexts/AuthProvider');
 import { useAuth } from '@/contexts/AuthProvider';
+import type { User } from '@supabase/supabase-js';
 
 vi.mocked(useAuth).mockReturnValue({
-  user: { id: 'user1' } as any,
+  user: { id: 'user1' } as User,
   profile: null,
   loading: false,
   error: null,

--- a/docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md
+++ b/docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md
@@ -1,0 +1,67 @@
+# Recipe Test Fixture Guide
+
+## Purpose
+
+Standard, type-safe `Recipe` fixtures for tests. Prevents shape drift and runtime surprises.
+
+## Minimal `Recipe` Fixture (copy/paste)
+
+```ts
+import type { Recipe } from '@/lib/types';
+
+export const createRecipe = (overrides: Partial<Recipe> = {}): Recipe => ({
+  id: 'test-recipe-1',
+  title: 'Test Recipe',
+  ingredients: ['ingredient1', 'ingredient2', 'ingredient3'],
+  instructions: 'Test cooking instructions for the recipe.',
+  notes: 'Test notes and tips for the recipe.',
+  categories: ['Italian', 'Dinner'],
+  image_url: 'https://example.com/image.jpg',
+  created_at: '2023-12-30T00:00:00Z',
+  updated_at: '2023-12-30T00:00:00Z',
+  user_id: 'user1',
+  is_public: false,
+  setup: ['Test setup instructions'],
+  cooking_time: null,
+  difficulty: null,
+  creator_rating: null,
+  current_version_id: null,
+  ...overrides,
+});
+```
+
+## Do/Don’t
+
+- Do: type fixtures as `Recipe` so TS enforces required fields
+- Do: use `overrides` to customize per test
+- Don’t: use wrong field types (e.g., `setup` must be `string[]`)
+
+## `useAuth` mock shape (for components relying on auth)
+
+The real hook returns `AuthContextType`. Mock with the full shape:
+
+```ts
+vi.mock('@/contexts/AuthProvider');
+import { useAuth } from '@/contexts/AuthProvider';
+
+vi.mocked(useAuth).mockReturnValue({
+  user: { id: 'user1' } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  signOut: vi.fn(async () => {}),
+  refreshProfile: vi.fn(async () => {}),
+});
+```
+
+Avoid using `isLoading`; the correct key is `loading`.
+
+## jest-dom matchers
+
+When using matchers like `toBeInTheDocument` or `toHaveTextContent`, ensure the test file imports:
+
+```ts
+import '@testing-library/jest-dom';
+```
+
+This provides types and runtime matchers to avoid lint/type errors.

--- a/src/__tests__/components/recipes/recipe-card.test.tsx
+++ b/src/__tests__/components/recipes/recipe-card.test.tsx
@@ -1,24 +1,27 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MockedFunction, Mocked } from 'vitest';
 import { RecipeCard } from '../../../components/recipes/recipe-card';
 import { useDeleteRecipe } from '../../../hooks/use-recipes';
 import { recipeApi } from '../../../lib/api';
 import { useAuth } from '../../../contexts/AuthProvider';
+import type { Recipe } from '../../../lib/types';
 
 // Mock the hooks and API
 vi.mock('../../../hooks/use-recipes');
 vi.mock('../../../lib/api');
 vi.mock('../../../contexts/AuthProvider');
 
-const mockUseDeleteRecipe = useDeleteRecipe as vi.MockedFunction<
+const mockUseDeleteRecipe = useDeleteRecipe as unknown as MockedFunction<
   typeof useDeleteRecipe
 >;
-const mockRecipeApi = recipeApi as vi.Mocked<typeof recipeApi>;
-const mockUseAuth = useAuth as vi.MockedFunction<typeof useAuth>;
+const mockRecipeApi = recipeApi as unknown as Mocked<typeof recipeApi>;
+const mockUseAuth = useAuth as unknown as MockedFunction<typeof useAuth>;
 
 // Mock recipe data
-const mockRecipe = {
+const mockRecipe: Recipe = {
   id: '1',
   title: 'Test Recipe',
   ingredients: ['ingredient1', 'ingredient2', 'ingredient3'],
@@ -30,7 +33,11 @@ const mockRecipe = {
   updated_at: '2023-12-30T00:00:00Z',
   user_id: 'user1',
   is_public: false,
-  setup: 'Test setup instructions',
+  setup: ['Test setup instructions'],
+  cooking_time: null,
+  difficulty: null,
+  creator_rating: null,
+  current_version_id: null,
 };
 
 // Mock callback functions
@@ -61,8 +68,11 @@ describe('RecipeCard', () => {
     // Mock useAuth hook
     mockUseAuth.mockReturnValue({
       user: { id: 'user1' },
-      isLoading: false,
+      profile: null,
+      loading: false,
       error: null,
+      signOut: vi.fn(async () => {}),
+      refreshProfile: vi.fn(async () => {}),
     } as unknown as ReturnType<typeof useAuth>);
   });
 
@@ -121,7 +131,7 @@ describe('RecipeCard', () => {
   });
 
   it('renders recipe without image when image_url is not provided', () => {
-    const recipeWithoutImage = { ...mockRecipe, image_url: undefined };
+    const recipeWithoutImage: Recipe = { ...mockRecipe, image_url: null };
 
     render(
       <TestWrapper>
@@ -281,8 +291,11 @@ describe('RecipeCard', () => {
   it('should not show Share button when user does not own recipe', () => {
     mockUseAuth.mockReturnValue({
       user: { id: 'different-user' },
-      isLoading: false,
+      profile: null,
+      loading: false,
       error: null,
+      signOut: vi.fn(async () => {}),
+      refreshProfile: vi.fn(async () => {}),
     } as unknown as ReturnType<typeof useAuth>);
 
     render(

--- a/src/__tests__/components/recipes/recipe-card.test.tsx
+++ b/src/__tests__/components/recipes/recipe-card.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { MockedFunction, Mocked } from 'vitest';
 import { RecipeCard } from '../../../components/recipes/recipe-card';
 import { useDeleteRecipe } from '../../../hooks/use-recipes';
 import { recipeApi } from '../../../lib/api';
@@ -14,11 +13,9 @@ vi.mock('../../../hooks/use-recipes');
 vi.mock('../../../lib/api');
 vi.mock('../../../contexts/AuthProvider');
 
-const mockUseDeleteRecipe = useDeleteRecipe as unknown as MockedFunction<
-  typeof useDeleteRecipe
->;
-const mockRecipeApi = recipeApi as unknown as Mocked<typeof recipeApi>;
-const mockUseAuth = useAuth as unknown as MockedFunction<typeof useAuth>;
+const mockUseDeleteRecipe = vi.mocked(useDeleteRecipe);
+const mockRecipeApi = vi.mocked(recipeApi);
+const mockUseAuth = vi.mocked(useAuth);
 
 // Mock recipe data
 const mockRecipe: Recipe = {


### PR DESCRIPTION
This pull request centralizes and improves the project's testing documentation by moving and updating guides, and also corrects and enforces type safety for recipe test fixtures and mocks in tests. It updates references across documentation to point to the new testing docs location, introduces dedicated guides for recipe fixtures and authentication mocks, and ensures that test files and mocks use the correct types and field shapes.

**Testing Documentation Centralization and Updates:**

* Moved the main testing guide to `docs/testing/TESTING-GUIDE.md` and added a stub referencing related guides and the original content in repo history.
* Added a dedicated guide for recipe test fixtures at `docs/testing/fixtures/RECIPE_FIXTURE_GUIDE.md`, providing a type-safe fixture pattern and best practices for mocking authentication in tests.
* Added an authentication testing documentation index at `docs/testing/auth/README.md` to centralize and reference authentication-related test docs.
* Updated all documentation references to the testing guide to point to the new location under `docs/testing/`. [[1]](diffhunk://#diff-6dc1003db885833202d3b2355ae274ce1735036fec6d3078751697fdffbb3e00L604-R604) [[2]](diffhunk://#diff-172af6fc0eca2d4d3ca0532bdf0bea382a3fb0801d6873937a1bdda715277be7L565-R565) [[3]](diffhunk://#diff-c7a96748af925047b0d598fec082ad2dadcd398d858d9162c5078768a0e0b3c3L540-R540)

**Recipe Test Type Safety and Mocking Improvements:**

* Updated the `recipe-card.test.tsx` test file to use the correct `Recipe` type for fixtures, fixed the `setup` field to be an array, added missing nullable fields, and ensured mocks for `useAuth` use the correct shape and keys (e.g., `loading` instead of `isLoading`). Also ensured `@testing-library/jest-dom` is imported for proper matcher support. [[1]](diffhunk://#diff-9cd09553490eeca0923547c79bf17a0a472c90fef507b7de10b2cccd9736a3fbR2-R24) [[2]](diffhunk://#diff-9cd09553490eeca0923547c79bf17a0a472c90fef507b7de10b2cccd9736a3fbL33-R40) [[3]](diffhunk://#diff-9cd09553490eeca0923547c79bf17a0a472c90fef507b7de10b2cccd9736a3fbL64-R75) [[4]](diffhunk://#diff-9cd09553490eeca0923547c79bf17a0a472c90fef507b7de10b2cccd9736a3fbL124-R134) [[5]](diffhunk://#diff-9cd09553490eeca0923547c79bf17a0a472c90fef507b7de10b2cccd9736a3fbL284-R298)