### PR TITLE
feat: Add health coach feature with direct persona navigation

### DIFF
--- a/scripts/seed/health/evaluations.ts
+++ b/scripts/seed/health/evaluations.ts
@@ -96,9 +96,9 @@ export async function seedEvaluationReports() {
       continue;
     }
 
-    // Build structured user_evaluation_report payload expected by the app
+    // Build structured report data payload expected by the app
     const isAlice = report.userEmail === 'alice@example.com';
-    const user_evaluation_report = {
+    const structuredReportData = {
       report_id: report.reportId,
       evaluation_date: report.evaluationDate,
       dietitian: report.dietitian,
@@ -259,7 +259,7 @@ export async function seedEvaluationReports() {
         evaluation_date: report.evaluationDate,
         dietitian: report.dietitian,
         report_version: report.reportVersion,
-        report_data: user_evaluation_report,
+        report_data: structuredReportData,
       },
       { onConflict: 'user_id,report_id' }
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ThemeProvider } from '@/components/ui/theme-provider';
 import Phase4Demo from '@/components/demo/Phase4Demo';
 import EvaluationReportPage from '@/pages/evaluation-reports/EvaluationReportPage';
 import { KitchenInventoryPage } from '@/features/kitchen-inventory';
+import { HealthCoachesPage } from '@/features/health-coach';
 import GlobalIngredientsPage from '@/pages/global-ingredients-page';
 import ShoppingCartPage from '@/pages/shopping-cart-page';
 import { SelectionProvider } from '@/contexts/SelectionContext';
@@ -170,6 +171,19 @@ function AppContent() {
               <Header />
               <main>
                 <EvaluationReportPage />
+              </main>
+            </div>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/health-coaches"
+        element={
+          <ProtectedRoute>
+            <div className="bg-base-100 min-h-screen">
+              <Header />
+              <main>
+                <HealthCoachesPage />
               </main>
             </div>
           </ProtectedRoute>

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -27,9 +27,13 @@ import { useAuth } from '@/contexts/AuthProvider';
 
 interface ChatInterfaceProps {
   onRecipeGenerated: (recipe: RecipeFormData) => void;
+  defaultPersona?: PersonaType;
 }
 
-export function ChatInterface({ onRecipeGenerated }: ChatInterfaceProps) {
+export function ChatInterface({
+  onRecipeGenerated,
+  defaultPersona,
+}: ChatInterfaceProps) {
   const { user } = useAuth();
   const {
     persona,
@@ -41,7 +45,7 @@ export function ChatInterface({ onRecipeGenerated }: ChatInterfaceProps) {
     sendMessage,
     startNewRecipe,
     changePersona,
-  } = useConversation();
+  } = useConversation(defaultPersona);
 
   const { selections, updateSelections } = useSelections();
 

--- a/src/features/health-coach/components/CoachCard.tsx
+++ b/src/features/health-coach/components/CoachCard.tsx
@@ -1,0 +1,40 @@
+import { createDaisyUICardClasses } from '@/lib/card-migration';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Brain } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { HealthCoach } from '../data/coaches';
+
+interface CoachCardProps {
+  coach: HealthCoach;
+}
+
+export function CoachCard({ coach }: CoachCardProps) {
+  return (
+    <div className={createDaisyUICardClasses('bordered')}>
+      <div className="card-body">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="card-title text-lg">{coach.name}</h3>
+            <p className="text-sm text-muted-foreground">{coach.title}</p>
+          </div>
+          {coach.isAssistantPowered ? (
+            <Badge variant="secondary" className="gap-1">
+              <Brain className="h-3 w-3" /> Assistant-powered
+            </Badge>
+          ) : null}
+        </div>
+
+        <p className="text-sm mt-2">{coach.description}</p>
+
+        <div className="mt-4">
+          <Button asChild>
+            <Link to={`/coach-chat?persona=${coach.id}`}>
+              Chat with {coach.name}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/health-coach/data/coaches.ts
+++ b/src/features/health-coach/data/coaches.ts
@@ -1,0 +1,34 @@
+export interface HealthCoach {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  isAssistantPowered?: boolean;
+}
+
+export const HEALTH_COACHES: HealthCoach[] = [
+  {
+    id: 'drLunaClearwater',
+    name: 'Dr. Luna Clearwater',
+    title: 'Personalized Health Assessment & Habit Formation Expert',
+    description:
+      'Evidence-informed wellness guidance and comprehensive health evaluations that produce structured reports.',
+    isAssistantPowered: true,
+  },
+  {
+    id: 'assistantNutritionist',
+    name: 'Dr. Sage Vitalis',
+    title: 'Integrative Culinary Medicine',
+    description:
+      'Combines traditional wisdom and modern nutrition to support daily habits and recovery.',
+    isAssistantPowered: true,
+  },
+  {
+    id: 'jamieBrightwell',
+    name: 'Dr. Jamie Brightwell',
+    title: 'Pediatric Culinary Wellness',
+    description:
+      'Play-based, evidence-backed guidance for kids and families to build positive food relationships.',
+    isAssistantPowered: true,
+  },
+];

--- a/src/features/health-coach/index.ts
+++ b/src/features/health-coach/index.ts
@@ -1,0 +1,1 @@
+export { HealthCoachesPage } from './page';

--- a/src/features/health-coach/page.tsx
+++ b/src/features/health-coach/page.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
+import { createDaisyUICardClasses } from '@/lib/card-migration';
+import { HEALTH_COACHES } from './data/coaches';
+import { CoachCard } from './components/CoachCard';
+
+export function HealthCoachesPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-cyan-50">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">Health Coaches</h1>
+          <p className="text-gray-600">
+            Explore our AI health coaches. For comprehensive evaluations and
+            structured reports, chat with{' '}
+            <span className="font-semibold">Dr. Luna Clearwater</span>.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {HEALTH_COACHES.map((coach) => (
+            <CoachCard key={coach.id} coach={coach} />
+          ))}
+        </div>
+
+        <div className={createDaisyUICardClasses('bordered mt-8')}>
+          <div className="card-body">
+            <h3 className="card-title text-lg">Medical Disclaimer</h3>
+            <p className="text-sm text-muted-foreground">
+              These AI health coaches provide general wellness guidance and are
+              not a substitute for professional medical advice, diagnosis, or
+              treatment. If you experience urgent symptoms, contact emergency
+              services.
+            </p>
+            <div className="mt-2">
+              <Button asChild variant="outline">
+                <Link to="/evaluation-report">
+                  View My Health Evaluation Reports
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/evaluation-report-db.ts
+++ b/src/lib/evaluation-report-db.ts
@@ -15,7 +15,7 @@ import type {
 // Handles legacy seeds where report_data did not wrap under user_evaluation_report.
 function normalizeDbReport(db: DatabaseEvaluationReport): EvaluationReport {
   const data = db.report_data as unknown as Record<string, unknown>;
-  if (data && (data as Record<string, unknown>).user_evaluation_report) {
+  if (data && data.user_evaluation_report) {
     return data as unknown as EvaluationReport;
   }
 

--- a/src/pages/coach-chat-page.tsx
+++ b/src/pages/coach-chat-page.tsx
@@ -1,10 +1,19 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { ChatInterface } from '@/components/chat/ChatInterface';
 import { Button } from '@/components/ui/button';
 
 export function CoachChatPage() {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const personaParam = params.get('persona') as
+    | 'chef'
+    | 'nutritionist'
+    | 'homeCook'
+    | 'assistantNutritionist'
+    | 'jamieBrightwell'
+    | 'drLunaClearwater'
+    | null;
 
   // For coach chat, we don't need recipe generation functionality
   const handleCoachResponse = () => {
@@ -39,7 +48,10 @@ export function CoachChatPage() {
         </div>
 
         <div className="bg-base-100 rounded-lg shadow-sm">
-          <ChatInterface onRecipeGenerated={handleCoachResponse} />
+          <ChatInterface
+            onRecipeGenerated={handleCoachResponse}
+            defaultPersona={personaParam ?? undefined}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/coach-chat-page.tsx
+++ b/src/pages/coach-chat-page.tsx
@@ -2,18 +2,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { ChatInterface } from '@/components/chat/ChatInterface';
 import { Button } from '@/components/ui/button';
+import type { PersonaType } from '@/lib/openai';
 
 export function CoachChatPage() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
-  const personaParam = params.get('persona') as
-    | 'chef'
-    | 'nutritionist'
-    | 'homeCook'
-    | 'assistantNutritionist'
-    | 'jamieBrightwell'
-    | 'drLunaClearwater'
-    | null;
+  const personaParam = params.get('persona') as PersonaType | null;
 
   // For coach chat, we don't need recipe generation functionality
   const handleCoachResponse = () => {

--- a/src/pages/evaluation-reports/EvaluationReportPage.tsx
+++ b/src/pages/evaluation-reports/EvaluationReportPage.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/lib/evaluation-report-db';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
 import { User, BookOpen, RefreshCw } from 'lucide-react';
 
 // Import components
@@ -164,9 +165,12 @@ export default function EvaluationReportPage() {
                 Clearwater yet.
               </p>
               <Button asChild>
-                <a href="/coach-chat?persona=drLunaClearwater">
+                <Link to="/coach-chat?persona=drLunaClearwater">
                   Start Health Evaluation
-                </a>
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="ml-2">
+                <Link to="/health-coaches">Browse Health Coaches</Link>
               </Button>
             </div>
           </div>
@@ -177,12 +181,19 @@ export default function EvaluationReportPage() {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold mb-2">Health Evaluation Reports</h1>
-        <p className="text-muted-foreground">
-          Comprehensive health assessments and personalized recommendations from
-          Dr. Luna Clearwater
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">Health Evaluation Reports</h1>
+          <p className="text-muted-foreground">
+            Comprehensive health assessments and personalized recommendations
+            from Dr. Luna Clearwater
+          </p>
+        </div>
+        <div className="mt-1">
+          <Button asChild variant="outline">
+            <Link to="/health-coaches">Browse Health Coaches</Link>
+          </Button>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // This proxy forwards /api requests to the local Vercel dev server
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:3000',
         changeOrigin: true,
         configure: (proxy) => {
           // Avoid proxy errors breaking HMR


### PR DESCRIPTION
- Create health coach feature with CoachCard components and data
- Add /health-coaches route showcasing Dr. Luna Clearwater and other coaches
- Implement direct persona loading for /coach-chat?persona=drLunaClearwater
- Fix evaluation report empty state with proper navigation buttons
- Update seed data to include comprehensive evaluation report structure
- Add data normalization layer for legacy evaluation reports
- Fix Vite proxy configuration to use port 3000 for API requests
- Replace anchor tags with React Router Links for SPA navigation

Features:
- Health coach showcase page with premium coach cards
- Direct chat access via URL parameters
- Improved evaluation report empty state
- Enhanced data structure for all evaluation report tabs
- Proper client-side navigation throughout the app