### PR TITLE
feat: Add cuisine staples modal to shopping cart page

### DIFF
--- a/src/__tests__/lib/cuisine-staples.test.ts
+++ b/src/__tests__/lib/cuisine-staples.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { CuisineStaplesManager } from '@/lib/shopping-cart/cuisine-staples';
+import { IngredientMatcher } from '@/lib/groceries/ingredient-matcher';
+
+describe('CuisineStaplesManager', () => {
+  it('should get available cuisines', () => {
+    const manager = new CuisineStaplesManager();
+    const cuisines = manager.getAvailableCuisines();
+
+    expect(cuisines).toContain('mexican');
+    expect(cuisines).toContain('italian');
+    expect(cuisines).toContain('asian');
+  });
+
+  it('should get cuisine staples', () => {
+    const manager = new CuisineStaplesManager();
+    const mexicanStaples = manager.getCuisineStaples('mexican');
+
+    expect(mexicanStaples).toHaveLength(11); // Based on our data
+    expect(mexicanStaples[0].ingredient).toBe('cumin');
+    expect(mexicanStaples[0].priority).toBe('essential');
+    expect(mexicanStaples[0].category).toBe('flavor_builders');
+  });
+
+  it('should find missing staples for Mexican cuisine', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({
+      flavor_builders: ['paprika'], // User has paprika but missing other essentials
+      fresh_produce: ['onion', 'garlic'], // User has some basics
+    });
+
+    const missing = manager.findMissingStaples(
+      'mexican',
+      {
+        flavor_builders: ['paprika'],
+        fresh_produce: ['onion', 'garlic'],
+      },
+      matcher
+    );
+
+    expect(missing.cuisine).toBe('Mexican');
+    expect(missing.missing.length).toBeGreaterThan(0);
+    expect(missing.available.length).toBeGreaterThan(0);
+    expect(missing.coverage).toBeGreaterThan(0);
+    expect(missing.coverage).toBeLessThan(100);
+  });
+
+  it('should find missing staples for Italian cuisine', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({
+      fresh_produce: ['tomato', 'garlic'],
+      dairy_cold: ['cheese'],
+    });
+
+    const missing = manager.findMissingStaples(
+      'italian',
+      {
+        fresh_produce: ['tomato', 'garlic'],
+        dairy_cold: ['cheese'],
+      },
+      matcher
+    );
+
+    expect(missing.cuisine).toBe('Italian');
+    expect(missing.missing.length).toBeGreaterThan(0);
+    expect(missing.available.length).toBeGreaterThan(0);
+  });
+
+  it('should get recommended additions', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({
+      fresh_produce: ['onion', 'garlic'], // User has basics
+    });
+
+    const recommendations = manager.getRecommendedAdditions(
+      'mexican',
+      {
+        fresh_produce: ['onion', 'garlic'],
+      },
+      matcher,
+      3
+    );
+
+    expect(recommendations.length).toBeLessThanOrEqual(3);
+    expect(recommendations.length).toBeGreaterThan(0);
+
+    // Should prioritize essential ingredients
+    const essentialCount = recommendations.filter(
+      (r) => r.priority === 'essential'
+    ).length;
+    expect(essentialCount).toBeGreaterThan(0);
+  });
+
+  it('should get all missing staples', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({
+      fresh_produce: ['onion', 'garlic'],
+      flavor_builders: ['paprika'],
+    });
+
+    const allMissing = manager.getAllMissingStaples(
+      {
+        fresh_produce: ['onion', 'garlic'],
+        flavor_builders: ['paprika'],
+      },
+      matcher
+    );
+
+    expect(allMissing.length).toBeGreaterThan(0);
+    expect(allMissing.every((m) => m.missing.length > 0)).toBe(true);
+  });
+
+  it('should handle empty groceries', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({});
+
+    const missing = manager.findMissingStaples('mexican', {}, matcher);
+
+    expect(missing.cuisine).toBe('Mexican');
+    expect(missing.missing.length).toBeGreaterThan(0);
+    expect(missing.available.length).toBe(0);
+    expect(missing.coverage).toBe(0);
+  });
+
+  it('should handle unknown cuisine', () => {
+    const manager = new CuisineStaplesManager();
+    const matcher = new IngredientMatcher({});
+
+    const missing = manager.findMissingStaples('unknown', {}, matcher);
+
+    expect(missing.cuisine).toBe('unknown');
+    expect(missing.missing).toEqual([]);
+    expect(missing.available).toEqual([]);
+    expect(missing.coverage).toBe(0);
+  });
+});

--- a/src/lib/shopping-cart/cuisine-staples.ts
+++ b/src/lib/shopping-cart/cuisine-staples.ts
@@ -1,0 +1,405 @@
+import { IngredientMatcher } from '@/lib/groceries/ingredient-matcher';
+
+export interface CuisineStaple {
+  ingredient: string;
+  category: string;
+  priority: 'essential' | 'recommended' | 'optional';
+  reason: string;
+  usage: string;
+  culturalContext?: string;
+}
+
+export interface CuisineStaplesData {
+  cuisine: string;
+  staples: CuisineStaple[];
+  description: string;
+  subStyles?: string[];
+}
+
+export interface MissingStaples {
+  cuisine: string;
+  missing: CuisineStaple[];
+  available: CuisineStaple[];
+  coverage: number; // Percentage of staples they have
+}
+
+export class CuisineStaplesManager {
+  private cuisineData: Record<string, CuisineStaplesData> = {
+    mexican: {
+      cuisine: 'Mexican',
+      description: 'Essential ingredients for authentic Mexican cooking',
+      subStyles: ['Traditional Mexican', 'Tex-Mex', 'Baja'],
+      staples: [
+        {
+          ingredient: 'cumin',
+          category: 'flavor_builders',
+          priority: 'essential',
+          reason: 'Core spice for Mexican flavor profile',
+          usage: 'Used in taco seasoning, chili, and rice dishes',
+          culturalContext: 'Essential for authentic Mexican taste',
+        },
+        {
+          ingredient: 'cilantro',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Fresh herb for garnishing and flavor',
+          usage: 'Garnish for tacos, salsas, and rice dishes',
+          culturalContext:
+            'Cannot make authentic Mexican food without cilantro',
+        },
+        {
+          ingredient: 'lime',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Acidic component for balance',
+          usage: 'Squeezed over tacos, in salsas, and marinades',
+          culturalContext: 'Lime is the soul of Mexican cuisine',
+        },
+        {
+          ingredient: 'jalapeño',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Primary heat source',
+          usage: 'Fresh in salsas, pickled for toppings, roasted for flavor',
+          culturalContext: 'The most common chili in Mexican cooking',
+        },
+        {
+          ingredient: 'avocado',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Base for guacamole and creamy elements',
+          usage: 'Guacamole, sliced on tacos, in salads',
+          culturalContext: 'Avocado is sacred in Mexican cuisine',
+        },
+        {
+          ingredient: 'onion',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Base for sofrito and salsas',
+          usage: 'Sautéed as base, raw in salsas, pickled for toppings',
+          culturalContext: 'Foundation of Mexican cooking',
+        },
+        {
+          ingredient: 'garlic',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Aromatic base for all dishes',
+          usage: 'Sautéed with onions, in marinades and salsas',
+          culturalContext: 'Essential aromatic in Mexican cuisine',
+        },
+        {
+          ingredient: 'oregano',
+          category: 'flavor_builders',
+          priority: 'recommended',
+          reason: 'Mexican oregano has distinct flavor',
+          usage: 'In chili, beans, and meat marinades',
+          culturalContext: 'Mexican oregano is different from Mediterranean',
+        },
+        {
+          ingredient: 'paprika',
+          category: 'flavor_builders',
+          priority: 'recommended',
+          reason: 'Adds color and mild heat',
+          usage: 'In spice blends, rubs, and for color',
+          culturalContext: 'Common in Tex-Mex and Northern Mexican cooking',
+        },
+        {
+          ingredient: 'black beans',
+          category: 'pantry_staples',
+          priority: 'recommended',
+          reason: 'Protein staple in Mexican cuisine',
+          usage: 'Refried beans, in rice, as side dish',
+          culturalContext: 'Beans are a daily staple in Mexican households',
+        },
+        {
+          ingredient: 'rice',
+          category: 'pantry_staples',
+          priority: 'recommended',
+          reason: 'Base for many Mexican dishes',
+          usage: 'Spanish rice, as side dish, in burritos',
+          culturalContext: 'Rice is served with almost every Mexican meal',
+        },
+      ],
+    },
+    italian: {
+      cuisine: 'Italian',
+      description: 'Classic ingredients for authentic Italian cooking',
+      subStyles: ['Northern Italian', 'Southern Italian', 'Sicilian'],
+      staples: [
+        {
+          ingredient: 'basil',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'The herb of Italian cuisine',
+          usage: 'Fresh in pesto, on pizza, in caprese salad',
+          culturalContext: 'Basil is the soul of Italian cooking',
+        },
+        {
+          ingredient: 'oregano',
+          category: 'flavor_builders',
+          priority: 'essential',
+          reason: 'Essential for pizza and tomato sauces',
+          usage: 'In pizza sauce, marinara, and meat dishes',
+          culturalContext: 'Oregano is synonymous with Italian pizza',
+        },
+        {
+          ingredient: 'parmesan',
+          category: 'dairy_cold',
+          priority: 'essential',
+          reason: 'The king of Italian cheeses',
+          usage: 'Grated over pasta, in risotto, on salads',
+          culturalContext: 'Parmigiano-Reggiano is the gold standard',
+        },
+        {
+          ingredient: 'olive oil',
+          category: 'pantry_staples',
+          priority: 'essential',
+          reason: 'The foundation of Italian cooking',
+          usage: 'Cooking, finishing, in dressings',
+          culturalContext: 'Extra virgin olive oil is sacred in Italy',
+        },
+        {
+          ingredient: 'garlic',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Essential aromatic base',
+          usage: 'Sautéed as base, in sauces, roasted',
+          culturalContext: 'Garlic is the foundation of Italian flavor',
+        },
+        {
+          ingredient: 'onion',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Base for soffritto and sauces',
+          usage: 'Sautéed as base, in sauces, caramelized',
+          culturalContext: 'Onion is the start of most Italian dishes',
+        },
+        {
+          ingredient: 'tomatoes',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Core of Italian cuisine',
+          usage: 'Fresh in salads, in sauces, roasted',
+          culturalContext: 'Tomatoes define Italian cooking',
+        },
+        {
+          ingredient: 'mozzarella',
+          category: 'dairy_cold',
+          priority: 'recommended',
+          reason: 'Essential for pizza and caprese',
+          usage: 'On pizza, in caprese salad, melted in dishes',
+          culturalContext: 'Fresh mozzarella is a must for authentic pizza',
+        },
+        {
+          ingredient: 'rosemary',
+          category: 'flavor_builders',
+          priority: 'recommended',
+          reason: 'Aromatic herb for meats and breads',
+          usage: 'With roasted meats, in focaccia, in marinades',
+          culturalContext: 'Rosemary grows wild in Italian countryside',
+        },
+        {
+          ingredient: 'thyme',
+          category: 'flavor_builders',
+          priority: 'recommended',
+          reason: 'Delicate herb for subtle flavor',
+          usage: 'In sauces, with vegetables, in marinades',
+          culturalContext: 'Thyme adds elegance to Italian dishes',
+        },
+      ],
+    },
+    asian: {
+      cuisine: 'Asian',
+      description: 'Essential ingredients for Asian cooking',
+      subStyles: ['Chinese', 'Japanese', 'Korean', 'Thai', 'Vietnamese'],
+      staples: [
+        {
+          ingredient: 'soy sauce',
+          category: 'pantry_staples',
+          priority: 'essential',
+          reason: 'The foundation of Asian flavor',
+          usage: 'In marinades, stir-fries, dipping sauces',
+          culturalContext: 'Soy sauce is the salt of Asian cuisine',
+        },
+        {
+          ingredient: 'ginger',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Essential aromatic and digestive aid',
+          usage: 'Fresh in stir-fries, pickled, in tea',
+          culturalContext: 'Ginger is medicine and flavor in Asian cooking',
+        },
+        {
+          ingredient: 'garlic',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Essential aromatic base',
+          usage: 'Minced in stir-fries, in marinades, roasted',
+          culturalContext: 'Garlic is the foundation of Asian flavor',
+        },
+        {
+          ingredient: 'sesame oil',
+          category: 'pantry_staples',
+          priority: 'essential',
+          reason: 'Distinctive Asian flavor and aroma',
+          usage: 'Finishing oil, in dressings, for aroma',
+          culturalContext: 'Sesame oil is the soul of Asian cooking',
+        },
+        {
+          ingredient: 'rice vinegar',
+          category: 'pantry_staples',
+          priority: 'essential',
+          reason: 'Mild acidity for Asian dishes',
+          usage: 'In dressings, pickles, dipping sauces',
+          culturalContext: 'Rice vinegar is gentler than Western vinegars',
+        },
+        {
+          ingredient: 'green onion',
+          category: 'fresh_produce',
+          priority: 'essential',
+          reason: 'Essential garnish and flavor',
+          usage: 'Garnish for everything, in stir-fries, in soups',
+          culturalContext: 'Green onions are used in almost every Asian dish',
+        },
+        {
+          ingredient: 'chili',
+          category: 'fresh_produce',
+          priority: 'recommended',
+          reason: 'Heat and color for Asian dishes',
+          usage: 'Fresh in stir-fries, dried in sauces, pickled',
+          culturalContext: 'Chili heat varies by region in Asia',
+        },
+        {
+          ingredient: 'coconut milk',
+          category: 'pantry_staples',
+          priority: 'recommended',
+          reason: 'Creamy base for curries and soups',
+          usage: 'In curries, soups, desserts',
+          culturalContext:
+            'Coconut milk is essential in Southeast Asian cooking',
+        },
+        {
+          ingredient: 'fish sauce',
+          category: 'pantry_staples',
+          priority: 'recommended',
+          reason: 'Umami depth for Southeast Asian dishes',
+          usage: 'In marinades, dipping sauces, curries',
+          culturalContext:
+            'Fish sauce is the secret ingredient in Southeast Asian cuisine',
+        },
+        {
+          ingredient: 'miso',
+          category: 'pantry_staples',
+          priority: 'optional',
+          reason: 'Fermented umami for Japanese dishes',
+          usage: 'In soups, marinades, dressings',
+          culturalContext: 'Miso is the soul of Japanese cooking',
+        },
+      ],
+    },
+  };
+
+  /**
+   * Get all available cuisines
+   */
+  getAvailableCuisines(): string[] {
+    return Object.keys(this.cuisineData);
+  }
+
+  /**
+   * Get staples for a specific cuisine
+   */
+  getCuisineStaples(cuisineKey: string): CuisineStaple[] {
+    return this.cuisineData[cuisineKey]?.staples || [];
+  }
+
+  /**
+   * Get cuisine data
+   */
+  getCuisineData(cuisineKey: string): CuisineStaplesData | null {
+    return this.cuisineData[cuisineKey] || null;
+  }
+
+  /**
+   * Find missing staples for a cuisine using existing IngredientMatcher
+   */
+  findMissingStaples(
+    cuisineKey: string,
+    _userGroceries: Record<string, string[]>,
+    ingredientMatcher: IngredientMatcher
+  ): MissingStaples {
+    const cuisineData = this.cuisineData[cuisineKey];
+    if (!cuisineData) {
+      return {
+        cuisine: cuisineKey,
+        missing: [],
+        available: [],
+        coverage: 0,
+      };
+    }
+
+    const available: CuisineStaple[] = [];
+    const missing: CuisineStaple[] = [];
+
+    // Check each staple against user's groceries using existing matcher
+    cuisineData.staples.forEach((staple) => {
+      const match = ingredientMatcher.matchIngredient(staple.ingredient);
+
+      if (match.matchType !== 'none' && match.confidence >= 50) {
+        available.push(staple);
+      } else {
+        missing.push(staple);
+      }
+    });
+
+    const coverage =
+      cuisineData.staples.length > 0
+        ? Math.round((available.length / cuisineData.staples.length) * 100)
+        : 0;
+
+    return {
+      cuisine: cuisineData.cuisine,
+      missing,
+      available,
+      coverage,
+    };
+  }
+
+  /**
+   * Get all missing staples across all cuisines
+   */
+  getAllMissingStaples(
+    userGroceries: Record<string, string[]>,
+    ingredientMatcher: IngredientMatcher
+  ): MissingStaples[] {
+    return this.getAvailableCuisines()
+      .map((cuisineKey) =>
+        this.findMissingStaples(cuisineKey, userGroceries, ingredientMatcher)
+      )
+      .filter((result) => result.missing.length > 0);
+  }
+
+  /**
+   * Get recommended staples to add for a specific cuisine
+   */
+  getRecommendedAdditions(
+    cuisineKey: string,
+    userGroceries: Record<string, string[]>,
+    ingredientMatcher: IngredientMatcher,
+    maxRecommendations: number = 5
+  ): CuisineStaple[] {
+    const missingStaples = this.findMissingStaples(
+      cuisineKey,
+      userGroceries,
+      ingredientMatcher
+    );
+
+    // Prioritize essential ingredients first, then recommended
+    return missingStaples.missing
+      .sort((a, b) => {
+        const priorityOrder = { essential: 0, recommended: 1, optional: 2 };
+        return priorityOrder[a.priority] - priorityOrder[b.priority];
+      })
+      .slice(0, maxRecommendations);
+  }
+}

--- a/src/pages/shopping-cart-page.tsx
+++ b/src/pages/shopping-cart-page.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import { useGroceriesQuery } from '@/hooks/useGroceriesQuery';
 import { useShoppingCartAI } from '@/hooks/useShoppingCartAI';
+import { useGroceries } from '@/hooks/useGroceries';
+import { useUserGroceryCart } from '@/hooks/useUserGroceryCart';
 import { ShoppingCartChat } from '@/components/shopping-cart/ShoppingCartChat';
+import { IngredientCard } from '@/components/groceries/IngredientCard';
 import { Check, ShoppingCart, Brain } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 
@@ -184,12 +187,132 @@ function ShoppingItemCard({
 // Main shopping cart page
 export default function ShoppingCartPage() {
   const groceries = useGroceriesQuery();
+  const { addIngredients } = useGroceries();
+  const {
+    loading: cartLoading,
+    removeFromCart,
+    isInCart,
+  } = useUserGroceryCart();
 
-  const { getChatResponse } = useShoppingCartAI();
+  const {
+    getChatResponse,
+    getAllMissingStaples,
+    getCuisineStaples,
+    getRecommendedAdditions,
+  } = useShoppingCartAI();
+
+  // Modal state management
+  const [selectedCuisine, setSelectedCuisine] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const [activeTab, setActiveTab] = useState<
     'incomplete' | 'completed' | 'all'
   >('incomplete');
+
+  // Kitchen inventory integration functions
+  const handleAddToGroceriesAsUnavailable = async (
+    category: string,
+    name: string
+  ) => {
+    try {
+      // Add to groceries in unavailable state
+      addIngredients(category, [name]);
+      toast({
+        title: 'Added to Kitchen',
+        description: `${name} added to kitchen inventory as unavailable (needs to be purchased)`,
+      });
+    } catch {
+      toast({
+        title: 'Error',
+        description: `Failed to add ${name} to kitchen inventory`,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleRemoveFromGroceries = async (name: string) => {
+    try {
+      await removeFromCart(name);
+      toast({
+        title: 'Removed from Kitchen',
+        description: `${name} removed from kitchen inventory`,
+      });
+    } catch {
+      toast({
+        title: 'Error',
+        description: `Failed to remove ${name} from kitchen inventory`,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  // Add multiple staples to groceries as unavailable
+  const addStaplesToGroceriesAsUnavailable = async (staples: string[]) => {
+    try {
+      for (const staple of staples) {
+        const category = categorizeIngredient(staple);
+        addIngredients(category, [staple]);
+      }
+
+      toast({
+        title: 'Added to Kitchen',
+        description: `${staples.length} ingredients added to kitchen inventory as unavailable`,
+      });
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to add some ingredients to kitchen inventory',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  // Simple ingredient categorization heuristic
+  const categorizeIngredient = (ingredient: string): string => {
+    const name = ingredient.toLowerCase();
+
+    if (
+      name.includes('oregano') ||
+      name.includes('cumin') ||
+      name.includes('paprika')
+    ) {
+      return 'flavor_builders';
+    }
+    if (
+      name.includes('onion') ||
+      name.includes('tomato') ||
+      name.includes('pepper')
+    ) {
+      return 'fresh_produce';
+    }
+    if (
+      name.includes('cheese') ||
+      name.includes('milk') ||
+      name.includes('butter')
+    ) {
+      return 'dairy_cold';
+    }
+    if (name.includes('oil') || name.includes('vinegar')) {
+      return 'cooking_essentials';
+    }
+    if (
+      name.includes('flour') ||
+      name.includes('rice') ||
+      name.includes('pasta')
+    ) {
+      return 'pantry_staples';
+    }
+    if (
+      name.includes('chicken') ||
+      name.includes('beef') ||
+      name.includes('fish')
+    ) {
+      return 'proteins';
+    }
+
+    return 'fresh_produce';
+  };
 
   // Simple format shopping list items
   const shoppingListItems = Object.entries(groceries.shoppingList);
@@ -478,6 +601,231 @@ export default function ShoppingCartPage() {
           </div>
         </div>
       </div>
+
+      {/* Cuisine Staples Display - Bottom Section */}
+      {(() => {
+        const allMissingStaples = getAllMissingStaples();
+        return (
+          allMissingStaples.length > 0 && (
+            <div className="mt-8">
+              <div className="card bg-base-100 shadow-sm border border-base-300">
+                <div className="card-body">
+                  <h3 className="card-title text-lg">
+                    <span className="text-primary">🌍</span> Cuisine Staples
+                  </h3>
+                  <p className="text-sm text-base-content/70 mb-4">
+                    Missing essential ingredients for authentic cooking
+                  </p>
+                  <div className="space-y-3">
+                    {allMissingStaples.map((cuisineData, index) => {
+                      // Get the complete list of staples for accurate coverage calculation
+                      const allStaples = getCuisineStaples(
+                        cuisineData.cuisine.toLowerCase()
+                      );
+
+                      // Calculate actual missing ingredients by checking each staple against user's kitchen
+                      const actuallyMissing = allStaples.filter(
+                        (staple) => !isInCart(staple.ingredient)
+                      );
+                      const actualCoverage =
+                        allStaples.length > 0
+                          ? Math.round(
+                              ((allStaples.length - actuallyMissing.length) /
+                                allStaples.length) *
+                                100
+                            )
+                          : 0;
+
+                      return (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between p-3 bg-base-200 rounded-lg"
+                        >
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-2">
+                              <span className="font-semibold">
+                                {cuisineData.cuisine}
+                              </span>
+                              <div className="badge badge-outline">
+                                {actualCoverage}% coverage
+                              </div>
+                              <div className="badge badge-warning">
+                                {actuallyMissing.length} missing
+                              </div>
+                              <div className="badge badge-info">
+                                {allStaples.length} total staples
+                              </div>
+                            </div>
+                            <div className="text-sm text-base-content/60">
+                              Missing:{' '}
+                              {actuallyMissing
+                                .slice(0, 3)
+                                .map((s) => s.ingredient)
+                                .join(', ')}
+                              {actuallyMissing.length > 3 &&
+                                ` +${actuallyMissing.length - 3} more`}
+                            </div>
+                          </div>
+                          <div className="flex gap-2">
+                            <button
+                              className="btn btn-sm btn-outline"
+                              onClick={() => {
+                                setSelectedCuisine(cuisineData.cuisine);
+                                setIsModalOpen(true);
+                              }}
+                            >
+                              View All ({allStaples.length})
+                            </button>
+                            <button
+                              className="btn btn-sm btn-primary"
+                              onClick={async () => {
+                                const recommendations = getRecommendedAdditions(
+                                  cuisineData.cuisine.toLowerCase(),
+                                  3
+                                );
+                                const ingredients = recommendations.map(
+                                  (s) => s.ingredient
+                                );
+                                await addStaplesToGroceriesAsUnavailable(
+                                  ingredients
+                                );
+                              }}
+                            >
+                              Add Essentials
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )
+        );
+      })()}
+
+      {/* Cuisine Staples Modal */}
+      {isModalOpen && selectedCuisine && (
+        <div className="modal modal-open">
+          <div className="modal-box max-w-6xl">
+            <h3 className="font-bold text-lg mb-4">
+              {selectedCuisine} Cuisine Staples
+              {(() => {
+                const allStaples = getCuisineStaples(
+                  selectedCuisine.toLowerCase()
+                );
+                // Calculate actual missing ingredients by checking each staple against user's kitchen
+                const actuallyMissing = allStaples.filter(
+                  (staple) => !isInCart(staple.ingredient)
+                );
+                const actualCoverage =
+                  allStaples.length > 0
+                    ? Math.round(
+                        ((allStaples.length - actuallyMissing.length) /
+                          allStaples.length) *
+                          100
+                      )
+                    : 0;
+                return (
+                  <div className="text-sm font-normal text-base-content/70 mt-1">
+                    {actualCoverage}% coverage • {actuallyMissing.length}{' '}
+                    missing • {allStaples.length} total staples
+                  </div>
+                );
+              })()}
+            </h3>
+
+            {/* Search functionality */}
+            <div className="mb-4">
+              <input
+                type="text"
+                placeholder="Search ingredients..."
+                className="input input-bordered w-full"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+
+            {/* Grid layout for ingredients */}
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 max-h-96 overflow-y-auto">
+              {getCuisineStaples(selectedCuisine.toLowerCase())
+                .filter(
+                  (staple) =>
+                    !searchQuery.trim() ||
+                    staple.ingredient
+                      .toLowerCase()
+                      .includes(searchQuery.toLowerCase()) ||
+                    staple.reason
+                      .toLowerCase()
+                      .includes(searchQuery.toLowerCase())
+                )
+                .map((staple) => {
+                  // Use the same logic as global ingredients page
+                  const isInUserCart = isInCart(staple.ingredient); // Multi-category aware check
+                  const isSystemAvailable = true; // All cuisine staples are system ingredients
+                  const isHidden = false; // Cuisine staples are never hidden
+
+                  return (
+                    <IngredientCard
+                      key={staple.ingredient}
+                      ingredient={{
+                        id: staple.ingredient,
+                        name: staple.ingredient,
+                        normalized_name: staple.ingredient.toLowerCase(),
+                        category: staple.category,
+                        synonyms: [],
+                        is_system: true,
+                        usage_count: 0,
+                        is_verified: true,
+                        first_seen_at: new Date().toISOString(),
+                        last_seen_at: new Date().toISOString(),
+                        created_by: 'system',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                      }}
+                      isInUserCart={isInUserCart}
+                      isSystemAvailable={isSystemAvailable}
+                      isHidden={isHidden}
+                      onAddToGroceries={handleAddToGroceriesAsUnavailable}
+                      onRemoveFromGroceries={handleRemoveFromGroceries}
+                      onToggleHidden={async () => {}}
+                      loading={groceries.loading || false}
+                      cartLoading={cartLoading || false}
+                    />
+                  );
+                })}
+            </div>
+
+            {/* Modal actions */}
+            <div className="modal-action">
+              <button
+                className="btn btn-primary"
+                onClick={async () => {
+                  const recommendations = getRecommendedAdditions(
+                    selectedCuisine.toLowerCase(),
+                    5
+                  );
+                  const ingredients = recommendations.map((s) => s.ingredient);
+                  await addStaplesToGroceriesAsUnavailable(ingredients);
+                }}
+              >
+                Add Top 5 Essentials to Kitchen (Unavailable)
+              </button>
+              <button
+                className="btn"
+                onClick={() => {
+                  setIsModalOpen(false);
+                  setSelectedCuisine(null);
+                  setSearchQuery('');
+                }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Implement modal for viewing all cuisine staples with accurate coverage calculation
- Add search functionality and grid layout for ingredient cards
- Integrate with kitchen inventory workflow (unavailable items → shopping list)
- Use same IngredientCard component as global ingredients page for consistency
- Move cuisine staples display to bottom third to prioritize shopping list
- Fix coverage calculation to use actual kitchen inventory state
- Add comprehensive tests for CuisineStaplesManager
- Ensure proper TypeScript types and error handling

Features:
- Modal shows all cuisine staples with search and filter
- Accurate coverage percentage based on actual kitchen inventory
- Add ingredients to kitchen as 'unavailable' (appears in shopping list)
- Consistent UI/UX with global ingredients page
- Real-time updates when ingredients are added/removed